### PR TITLE
normalize unicode string

### DIFF
--- a/Workflow/gd
+++ b/Workflow/gd
@@ -5,7 +5,7 @@ require 'json'
 require 'sqlite3'
 
 Dir_only = ARGV[0] == 'dir_only' ? 'isdir = 1 AND' : ''
-Query = ARGV[1].split(' ').map { |w| "%#{w}%" }
+Query = ARGV[1].split(' ').map { |w| "%#{w.unicode_normalize}%" }
 Limit = ENV['result_limit'].to_i <= 0 ? 50 : ENV['result_limit'].to_i
 Tmp_file = File.join(ENV['alfred_workflow_cache'], 'tmp.db')
 Cache_file = File.join(ENV['alfred_workflow_cache'], 'cache.db')


### PR DESCRIPTION
Correct when entering a Japanese query.
Some Japanese characters are represented by two Unicode characters.
Therefore, non-normalized queries will not hit the DB search.
Normalization makes it a Unicode single character. Then it will hit the search.

```
irb(main):009:0> "プ".length
=> 2
irb(main):010:0> "プ".length
=> 1
irb(main):011:0> "プ".unicode_normalize.length // character on the first line
=> 1
```