### PR TITLE
Enable gd for full path prefix query to support query specific Google account in the multiple accounts settings

### DIFF
--- a/Workflow/gd
+++ b/Workflow/gd
@@ -6,6 +6,7 @@ require 'sqlite3'
 
 Dir_only = ARGV[0] == 'dir_only' ? 'isdir = 1 AND' : ''
 Query = ARGV[1].split(' ').map { |w| "%#{w.unicode_normalize}%" }
+Full_path_prefix = ARGV[2]
 Limit = ENV['result_limit'].to_i <= 0 ? 50 : ENV['result_limit'].to_i
 Tmp_file = File.join(ENV['alfred_workflow_cache'], 'tmp.db')
 Cache_file = File.join(ENV['alfred_workflow_cache'], 'cache.db')
@@ -26,7 +27,14 @@ end
 
 # Filter paths
 db = SQLite3::Database.new(Cache_file)
-Results = db.execute("SELECT fullpath FROM main WHERE #{Dir_only} #{Array.new(Query.length, 'basename LIKE ?').join(' AND ')} ORDER BY accesstime DESC LIMIT ?;", Query, Limit).flatten
+
+if Full_path_prefix == nil or Full_path_prefix.empty?
+  sql = "SELECT fullpath FROM main WHERE #{Dir_only} #{Array.new(Query.length, 'basename LIKE ?').join(' AND ')} ORDER BY accesstime DESC LIMIT ?;"
+else
+  sql = "SELECT fullpath FROM main WHERE #{Dir_only} #{Array.new(Query.length, 'basename LIKE ?').join(' AND ')} AND fullpath like '#{Full_path_prefix}%' ORDER BY accesstime DESC LIMIT ?;"
+end
+Results = db.execute(sql, Query, Limit).flatten
+
 
 Script_filter_items = Results.each_with_object([]) { |path, array|
   short_path = path.sub(%r{^/Users/.+?/}, '~/').sub(%r{^~/Library/CloudStorage/}, '')


### PR DESCRIPTION
Add a 3rd args in the gd script to enable full path prefix query

How to use:
To search files in specific account:
./gd 'all' "${1}" "/Users/user/Library/CloudStorage/GoogleDrive-xyz@gmail.com"
To search files in all account:
./gd 'all' "${1}" 

To search director in specific account:
./gd 'dir_only' "${1}" "/Users/user/Library/CloudStorage/GoogleDrive-xyz@gmail.com"